### PR TITLE
Fix leap year check

### DIFF
--- a/src/drawables.cpp
+++ b/src/drawables.cpp
@@ -45,7 +45,7 @@ chronic::drawables::timestamp::timestamp(int x, int y, const tm *t, int color) :
     digits[3].x = digits[2].x + number::width;
     digits[4].x = digits[3].x + number::width + 2;
 
-    const bool leap = (year % 4 == 0) && (year % 100 != 0);
+    const bool leap = (year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0));
     const int days = leap? 366 : 365;
     const float percent = float(t->tm_yday) / float(days);
     progress.percent = percent;


### PR DESCRIPTION
The current check does not account for the end-of-century rule, which states that end-of-century dates do not count as leap years, except if the date is divisible by 0.[0]

[0]: https://www.rmg.co.uk/discover/explore/which-years-are-leap-years-and-can-you-have-leap-seconds